### PR TITLE
Add KNOWN_ISSUES reference

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,0 +1,17 @@
+1.
+**Problem**: Both images `foodsoft` and `members` have issues while using the `apt update` command .
+
+_The stacktrace explained:_
+```
+W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)
+
+E: Some index files failed to download. They have been ignored, or old ones used instead.
+```
+**How to fix it:**
+Before running anything with `apt` please temporarly paste this command on the Dockerfile in both folders `foodsoft` and `members`:
+
+```
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+````
+
+Reference: https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease

--- a/README.md
+++ b/README.md
@@ -160,3 +160,5 @@ docker-compose run --rm foodsoft bundle exec rake db:migrate
 docker-compose restart foodsoft foodsoft_worker foodsoft_smtp
 ```
 
+### Known Issues
+See: KNOWN_ISSUES.md


### PR DESCRIPTION
I would not add the command directly in the Dockerfile, since it's possible that `debian:jessie` Docker image will be updated to work correctly in the near future. Till then, we can use this just as an indication for new builds.

